### PR TITLE
add failing spec if initializer needs AR

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
@@ -83,6 +84,7 @@ DEPENDENCIES
   rspec
   rubocop
   rubocop-performance
+  sqlite3
 
 BUNDLED WITH
    1.17.3

--- a/fishplate.gemspec
+++ b/fishplate.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-performance'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/spec/app/app.rb
+++ b/spec/app/app.rb
@@ -1,0 +1,11 @@
+ENV['RACK_ENV'] = 'test'
+
+Fishplate.logger = Logger.new(IO::NULL)
+
+class TestApp
+  def initialize
+    A9n.root = './spec/app'
+    A9n.env = ENV['RACK_ENV']
+    A9n.load
+  end
+end

--- a/spec/app/config/database.yml
+++ b/spec/app/config/database.yml
@@ -1,0 +1,3 @@
+test:
+  adapter: sqlite3
+  database: /tmp/test.sqlite3

--- a/spec/app/config/initializers/active_record.rb
+++ b/spec/app/config/initializers/active_record.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Base.connection

--- a/spec/fishplate_spec.rb
+++ b/spec/fishplate_spec.rb
@@ -1,5 +1,19 @@
+require './spec/app/app'
+
 RSpec.describe Fishplate do
   it "has a version number" do
     expect(Fishplate::VERSION).not_to be nil
+  end
+
+  describe '.setup!' do
+    subject { Fishplate.setup! }
+
+    context 'when an app is configured correctly' do
+      before { TestApp.new }
+
+      it 'initializes without exception' do
+        expect { subject }.to_not raise_exception
+      end
+    end
   end
 end


### PR DESCRIPTION
Not the most amazing test case, but at least it's one integration test that we can continue to add more features around.  This was failing before PR #14 was merged, and now it's passing 😄 